### PR TITLE
Fix ugly horizontal scrollbar due to bad page width

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -56,7 +56,7 @@ export default {
 
 body {
   margin: 0;
-  width: 100vw;
+  width: 100%;
   height: 100%;
   position: relative;
 


### PR DESCRIPTION
Fixes horizontal scrollbar being shown because the page width is above 100%.

![2019-06-15 20_56_07-NVIDIA GeForce Overlay](https://user-images.githubusercontent.com/3010353/59555795-0d336980-8fb0-11e9-96e8-7cbf2cc24476.png)
