### PR TITLE
Remove HTTPS from dev environment

### DIFF
--- a/build/webpack.dev.conf.js
+++ b/build/webpack.dev.conf.js
@@ -22,7 +22,7 @@ const devWebpackConfig = merge(baseWebpackConfig, {
 
   // these devServer options should be customized in /config/index.js
   devServer: {
-    https: true,
+    https: config.dev.https,
     clientLogLevel: 'warning',
     historyApiFallback: {
       rewrites: [

--- a/config/index.js
+++ b/config/index.js
@@ -15,6 +15,7 @@ module.exports = {
     // Various Dev Server settings
     host: 'localhost', // can be overwritten by process.env.HOST
     port: 8080, // can be overwritten by process.env.PORT, if port is in use, a free one will be determined
+    https: false,
     autoOpenBrowser: false,
     errorOverlay: true,
     notifyOnErrors: true,


### PR DESCRIPTION
When booting the dev environment, the user is presented with the following message in the terminal:
> Your application is running here: http://localhost:8080

However, this link is broken because the website is only served via HTTPS.
Since there is no apparent reason to serve HTTPS in the dev environment (correct me if I am wrong), this PR disables it on the development environment, so that everything is served over HTTP.
